### PR TITLE
Fix for Rails 5 and Windows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       bitcoin-ruby (= 0.0.11)
       ffi (= 1.9.18)
       hashie (~> 3.5, >= 3.5.5)
-      json (~> 1.8, >= 1.8.6)
+      json (~> 2.0, >= 2.0.2)
       logging (~> 2.2, >= 2.2.0)
       net-http-persistent (~> 2.9, >= 2.9.4)
 
@@ -29,7 +29,7 @@ GEM
     ffi (1.9.18)
     hashdiff (0.3.6)
     hashie (3.5.6)
-    json (1.8.6)
+    json (2.0.2)
     little-plugger (1.1.4)
     logging (2.2.2)
       little-plugger (~> 1.1)

--- a/lib/radiator/api.rb
+++ b/lib/radiator/api.rb
@@ -14,7 +14,7 @@ module Radiator
       @debug = !!options[:debug]
       @net_http_persistent_enabled = true
       @logger = options[:logger] || Radiator.logger
-      @hashie_logger = options[:hashie_logger] || Logger.new('/dev/null')
+      @hashie_logger = options[:hashie_logger] || Logger.new(nil)
       
       Hashie.logger = @hashie_logger
       @method_names = nil

--- a/radiator.gemspec
+++ b/radiator.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   # Maximum for net-http-persistent is 2.9.4, required by ruby-2.0.0-p645, which
   # is the darwin default at the moment.
   spec.add_dependency('net-http-persistent', '~> 2.9', '>= 2.9.4')
-  spec.add_dependency('json', '~> 1.8', '>= 1.8.6')
+  spec.add_dependency('json', '~> 2.0', '>= 2.0.2')
   spec.add_dependency('logging', '~> 2.2', '>= 2.2.0')
   spec.add_dependency('hashie', '~> 3.5', '>= 3.5.5')
   spec.add_dependency('bitcoin-ruby', '0.0.11')


### PR DESCRIPTION
Rails 5 needs json version 2 (it breaks no tests).

Windows has no `/dev/null` and just giving it nil will ignore the logger completely. This will probably be faster anyways, as no logging has to be produced and disregarded by the OS.